### PR TITLE
Updated the version of ssh2 to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "mysql2": "^1.2.0",
-    "ssh2": "^0.5.4"
+    "ssh2": "^1.4.0"
   },
   "name": "mysql-ssh",
   "version": "1.0.6",


### PR DESCRIPTION
Versions less than 1.4.0 have a severe vulnerability which is explained here https://github.com/advisories/GHSA-652h-xwhf-q4h6